### PR TITLE
Fix typo in README.md: broken link syntax

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -2,8 +2,8 @@
 
 ## Full Safe Harbor
  
-If all of the requirements in the [Terms](/terms) are met, an organization may display the (disclose.io)[https://disclose.io/] "Full Safe Harbor" mark, in conjunction with their authorized security research program's policies, to indicate their intention to provide safe harbor for good-faith security research.
+If all of the requirements in the [Terms](/terms) are met, an organization may display the [disclose.io](https://disclose.io/) "Full Safe Harbor" mark, in conjunction with their authorized security research program's policies, to indicate their intention to provide safe harbor for good-faith security research.
  
 ## Partial Safe Harbor
  
-Organizations that have not met all of the Terms, but do give a clear goodwill statement about not pursuing legal action related to security research, can be acknowledged through the use of the "Partial Safe Harbor" (disclose.io)[https://disclose.io/] mark.
+Organizations that have not met all of the Terms, but do give a clear goodwill statement about not pursuing legal action related to security research, can be acknowledged through the use of the "Partial Safe Harbor" [disclose.io](https://disclose.io/) mark.


### PR DESCRIPTION
Swapped '[]' and '()' so the links will work.